### PR TITLE
Adopt recur

### DIFF
--- a/betree.hpp
+++ b/betree.hpp
@@ -716,7 +716,6 @@ private:
    
 
     // Adopt() recursively from the bottom to the top.
-    // Nodes only adopt if they recently got bigger max_pivots (flagged as ready_for_adoption)
     void recursive_adopt(betree &bet) {
 	// For all kids, call adopt()
 	for (auto it = pivots.begin(); it != pivots.end(); ++it) {
@@ -1071,7 +1070,6 @@ private:
       return result;
     }
 
-    //Value query(const betree &bet, const Key k)
     Value query(betree &bet, const Key k)
     {
       debug(std::cout << "Querying " << this << std::endl);

--- a/test.cpp
+++ b/test.cpp
@@ -409,8 +409,10 @@ int main(int argc, char **argv)
   one_file_per_object_backing_store ofpobs(backing_store_dir);
   swap_space sspace(&ofpobs, cache_size);
   
+  // Launch test with non-adaptive tree:
   //betree<uint64_t, std::string> b(&sspace, max_node_size, min_flush_size);
   
+  // Launch test with adaptive tree:
   // (sspace, maxnodesize, minnodesize, minflushsize, isdynamic, startingepsilon, tunableepsilonlevel, opsbeforeupdate, windowsize)
   betree<uint64_t, std::string> b(&sspace, max_node_size, max_node_size/4, min_flush_size, true, 0.4, 0, 100, 100);
   


### PR DESCRIPTION
Fixed bug in adoptive_recursive method so it actually calls itself. Added adopt() in recursive query method if node is flagged as ready_for_adoption. If at node_level, do recursive_adopt when flagged