### PR TITLE
Update epsilon proper

### DIFF
--- a/betree.hpp
+++ b/betree.hpp
@@ -1388,11 +1388,11 @@ public:
   {
     Value v = root->query(*this, k);
 
-    if (is_dynamic){
-      if (root->ready_for_adoption){
-	root->recursive_adopt(*this);
-      }
+    // Shorten tree if ready
+    if (is_dynamic && root->ready_for_adoption){
+      root->recursive_adopt(*this);
     }
+
     return v;
   }
 


### PR DESCRIPTION
in flush, calculates max_messages properly when inheriting parent epsilon. Changed messages to be apply()ed to this node in adopt(), not forwarded to grandchildren. Changed recursive adopt to happen at the root, and adopt for all nodes flagged as ready_for_adopt. Created recursive method to flag the node at the node level, and all nodes that inherit from it, as ready_for_adoption. 